### PR TITLE
minor changes in the Github action workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [stable]
   pull_request:
-    branches: [main, master]
+    branches: [stable]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Changed just the pkgdown.yaml GH action: now it is triggered when a new release has been published.